### PR TITLE
[Feat] 문의 관련 엔티티 디폴트 생성자 어노테이션으로 정의

### DIFF
--- a/src/main/java/trend_setter/turtlerun/inquiry/entity/Faq.java
+++ b/src/main/java/trend_setter/turtlerun/inquiry/entity/Faq.java
@@ -1,12 +1,15 @@
 package trend_setter.turtlerun.inquiry.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import trend_setter.turtlerun.global.common.BaseTimeEntity;
 import trend_setter.turtlerun.user.User;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "faqs")
 @Getter
 public class Faq extends BaseTimeEntity {
@@ -25,9 +28,6 @@ public class Faq extends BaseTimeEntity {
 
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content; // 내용
-
-    protected Faq() {
-    }
 
     @Builder
     public Faq(User user, String title, String content) {

--- a/src/main/java/trend_setter/turtlerun/inquiry/entity/Inquiry.java
+++ b/src/main/java/trend_setter/turtlerun/inquiry/entity/Inquiry.java
@@ -1,12 +1,15 @@
 package trend_setter.turtlerun.inquiry.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import trend_setter.turtlerun.global.common.BaseTimeEntity;
 import trend_setter.turtlerun.user.User;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "inquiries")
 @Getter
 public class Inquiry extends BaseTimeEntity {
@@ -29,9 +32,6 @@ public class Inquiry extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private InquiryStatus inquiryStatus = InquiryStatus.PENDING; // 상태 (PENDING, ANSWERED)
-
-    protected Inquiry() {
-    }
 
     @Builder
     public Inquiry(User user, String title, String content, InquiryStatus inquiryStatus) {

--- a/src/main/java/trend_setter/turtlerun/inquiry/entity/InquiryResponse.java
+++ b/src/main/java/trend_setter/turtlerun/inquiry/entity/InquiryResponse.java
@@ -1,12 +1,15 @@
 package trend_setter.turtlerun.inquiry.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import trend_setter.turtlerun.global.common.BaseTimeEntity;
 import trend_setter.turtlerun.user.User;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "inquiry_responses")
 @Getter
 public class InquiryResponse extends BaseTimeEntity {
@@ -26,9 +29,6 @@ public class InquiryResponse extends BaseTimeEntity {
 
     @Column(columnDefinition = "TEXT", nullable = false)
     private String response; // 답변 내용
-
-    protected InquiryResponse() {
-    }
 
     @Builder
     public InquiryResponse(User user, Inquiry inquiry, String response) {

--- a/src/main/java/trend_setter/turtlerun/inquiry/entity/InquiryStatus.java
+++ b/src/main/java/trend_setter/turtlerun/inquiry/entity/InquiryStatus.java
@@ -1,6 +1,5 @@
 package trend_setter.turtlerun.inquiry.entity;
 
 public enum InquiryStatus {
-    PENDING,
-    ANSWERED
+    PENDING, ANSWERED
 }


### PR DESCRIPTION
## 💡 이슈
resolve #13 

## 🤩 개요
문의 관련 엔티티에서 디폴트 생성자를 어노테이션을 사용하여 정의하도록 수정

## 🧑‍💻 작업 사항
`@NoArgsConstructor(access = AccessLevel.PROTECTED)`로 리팩토링

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.