### PR TITLE
[Feat] 문의하기 기능 2차 구현

### DIFF
--- a/src/main/java/trend_setter/turtlerun/inquiry/controller/InquiryController.java
+++ b/src/main/java/trend_setter/turtlerun/inquiry/controller/InquiryController.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import trend_setter.turtlerun.inquiry.dto.InquiryListDto;
+import trend_setter.turtlerun.inquiry.dto.InquiryResponseDto;
+import trend_setter.turtlerun.inquiry.dto.InquiryStatusUpdateDto;
 import trend_setter.turtlerun.inquiry.dto.InquiryWriteDto;
 import trend_setter.turtlerun.inquiry.dto.InquiryDetailDto;
 import trend_setter.turtlerun.inquiry.service.InquiryService;
@@ -16,7 +18,7 @@ public class InquiryController {
 
     private final InquiryService inquiryService;
 
-    // 게시글 목록 조회
+    // 게시글 목록 조회 (관리자 전용)
     @GetMapping
     public ResponseEntity<List<InquiryListDto>> getInquiries() {
         List<InquiryListDto> inquiries = inquiryService.getInquiries();
@@ -33,8 +35,41 @@ public class InquiryController {
     // 게시글 작성
     @PostMapping
     public ResponseEntity<Long> createInquiry(@RequestBody InquiryWriteDto requestDto,
-        @RequestParam String userEmail) {
-        Long inquiryId = inquiryService.createInquiry(requestDto, userEmail);
+        @RequestParam String nickname) {
+        Long inquiryId = inquiryService.createInquiry(requestDto, nickname);
         return ResponseEntity.ok(inquiryId);
+    }
+
+    // 게시글에 답글 달기 (관리자 전용)
+    @PostMapping("/{id}/response")
+    public ResponseEntity<InquiryResponseDto> createResponse(@PathVariable Long id,
+        @RequestBody InquiryResponseDto responseDto, @RequestParam Long adminId) {
+        InquiryResponseDto createdResponse = inquiryService.createResponse(id, responseDto,
+            adminId);
+        return ResponseEntity.ok(createdResponse);
+    }
+
+    // 제목으로 검색하기
+    @GetMapping("/search/title")
+    public ResponseEntity<List<InquiryListDto>> searchInquiriesByTitle(
+        @RequestParam String keyword) {
+        List<InquiryListDto> results = inquiryService.searchInquiriesByTitle(keyword);
+        return ResponseEntity.ok(results);
+    }
+
+    // 닉네임으로 검색하기
+    @GetMapping("/search/nickname")
+    public ResponseEntity<List<InquiryListDto>> searchInquiriesByNickname(
+        @RequestParam String nickname) {
+        List<InquiryListDto> results = inquiryService.searchInquiriesByNickname(nickname);
+        return ResponseEntity.ok(results);
+    }
+
+    // 게시글 상태 변경
+    @PutMapping("/{id}/status")
+    public ResponseEntity<Void> updateInquiryStatus(@PathVariable Long id,
+        @RequestBody InquiryStatusUpdateDto statusUpdateDto) {
+        inquiryService.updateInquiryStatus(id, statusUpdateDto);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/trend_setter/turtlerun/inquiry/dto/InquiryDetailDto.java
+++ b/src/main/java/trend_setter/turtlerun/inquiry/dto/InquiryDetailDto.java
@@ -9,4 +9,4 @@ public record InquiryDetailDto(
     String content, // 내용
     InquiryStatus inquiryStatus, // 상태
     String userEmail // 작성자 이메일
-) {}
+) implements InquiryDto {}

--- a/src/main/java/trend_setter/turtlerun/inquiry/dto/InquiryDto.java
+++ b/src/main/java/trend_setter/turtlerun/inquiry/dto/InquiryDto.java
@@ -1,0 +1,5 @@
+package trend_setter.turtlerun.inquiry.dto;
+
+public interface InquiryDto {
+
+}

--- a/src/main/java/trend_setter/turtlerun/inquiry/dto/InquiryResponseDto.java
+++ b/src/main/java/trend_setter/turtlerun/inquiry/dto/InquiryResponseDto.java
@@ -1,0 +1,6 @@
+package trend_setter.turtlerun.inquiry.dto;
+
+public record InquiryResponseDto(
+
+    String response // 답글 내용
+) implements InquiryDto {}

--- a/src/main/java/trend_setter/turtlerun/inquiry/dto/InquirySearchDto.java
+++ b/src/main/java/trend_setter/turtlerun/inquiry/dto/InquirySearchDto.java
@@ -1,0 +1,6 @@
+package trend_setter.turtlerun.inquiry.dto;
+
+public record InquirySearchDto(
+
+    String keyword // 검색 키워드
+) implements InquiryDto {}

--- a/src/main/java/trend_setter/turtlerun/inquiry/dto/InquiryStatusUpdateDto.java
+++ b/src/main/java/trend_setter/turtlerun/inquiry/dto/InquiryStatusUpdateDto.java
@@ -2,9 +2,7 @@ package trend_setter.turtlerun.inquiry.dto;
 
 import trend_setter.turtlerun.inquiry.entity.InquiryStatus;
 
-public record InquiryListDto(
+public record InquiryStatusUpdateDto(
 
-    Long id, // 문의 ID
-    String title, // 제목
-    InquiryStatus inquiryStatus // 상태
+    InquiryStatus newStatus // 변경할 상태
 ) implements InquiryDto {}

--- a/src/main/java/trend_setter/turtlerun/inquiry/dto/InquiryWriteDto.java
+++ b/src/main/java/trend_setter/turtlerun/inquiry/dto/InquiryWriteDto.java
@@ -4,4 +4,4 @@ public record InquiryWriteDto(
 
     String title, // 제목
     String content // 내용
-) {}
+) implements InquiryDto {}

--- a/src/main/java/trend_setter/turtlerun/inquiry/entity/Inquiry.java
+++ b/src/main/java/trend_setter/turtlerun/inquiry/entity/Inquiry.java
@@ -6,6 +6,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import trend_setter.turtlerun.global.common.BaseTimeEntity;
+import trend_setter.turtlerun.inquiry.dto.InquiryDto;
+import trend_setter.turtlerun.inquiry.dto.InquiryResponseDto;
+import trend_setter.turtlerun.inquiry.dto.InquiryStatusUpdateDto;
 import trend_setter.turtlerun.user.User;
 
 @Entity
@@ -39,5 +42,14 @@ public class Inquiry extends BaseTimeEntity {
         this.title = title;
         this.content = content;
         this.inquiryStatus = inquiryStatus != null ? inquiryStatus : InquiryStatus.PENDING;
+    }
+
+    // 답변 상태 수정 메서드
+    public void updateInquiryStatus(InquiryDto inquiryDto) {
+        if (inquiryDto instanceof InquiryStatusUpdateDto inquiryStatusUpdateDto) {
+            this.inquiryStatus = inquiryStatusUpdateDto.newStatus();
+        } else if (inquiryDto instanceof InquiryResponseDto inquiryResponseDto) {
+            this.inquiryStatus = InquiryStatus.ANSWERED;
+        }
     }
 }

--- a/src/main/java/trend_setter/turtlerun/inquiry/repository/InquiryRepository.java
+++ b/src/main/java/trend_setter/turtlerun/inquiry/repository/InquiryRepository.java
@@ -1,8 +1,14 @@
 package trend_setter.turtlerun.inquiry.repository;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import trend_setter.turtlerun.inquiry.entity.Inquiry;
 
 public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
 
+    // 제목을 기준으로 검색
+    List<Inquiry> findByTitleContaining(String title);
+
+    // 닉네임을 기준으로 검색
+    List<Inquiry> findByUser_NicknameContaining(String nickname);
 }

--- a/src/main/java/trend_setter/turtlerun/inquiry/repository/InquiryResponseRepository.java
+++ b/src/main/java/trend_setter/turtlerun/inquiry/repository/InquiryResponseRepository.java
@@ -1,0 +1,8 @@
+package trend_setter.turtlerun.inquiry.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import trend_setter.turtlerun.inquiry.entity.InquiryResponse;
+
+public interface InquiryResponseRepository extends JpaRepository<InquiryResponse, Long> {
+
+}

--- a/src/main/java/trend_setter/turtlerun/inquiry/service/InquiryService.java
+++ b/src/main/java/trend_setter/turtlerun/inquiry/service/InquiryService.java
@@ -6,11 +6,17 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import trend_setter.turtlerun.inquiry.dto.InquiryListDto;
+import trend_setter.turtlerun.inquiry.dto.InquiryResponseDto;
+import trend_setter.turtlerun.inquiry.dto.InquirySearchDto;
+import trend_setter.turtlerun.inquiry.dto.InquiryStatusUpdateDto;
 import trend_setter.turtlerun.inquiry.dto.InquiryWriteDto;
 import trend_setter.turtlerun.inquiry.dto.InquiryDetailDto;
 import trend_setter.turtlerun.inquiry.entity.Inquiry;
+import trend_setter.turtlerun.inquiry.entity.InquiryResponse;
+import trend_setter.turtlerun.inquiry.repository.InquiryResponseRepository;
 import trend_setter.turtlerun.inquiry.utils.InquiryMapper;
 import trend_setter.turtlerun.inquiry.repository.InquiryRepository;
+import trend_setter.turtlerun.inquiry.utils.InquiryResponseMapper;
 import trend_setter.turtlerun.user.User;
 import trend_setter.turtlerun.user.repository.UserRepository;
 
@@ -19,10 +25,10 @@ import trend_setter.turtlerun.user.repository.UserRepository;
 public class InquiryService {
 
     private final InquiryRepository inquiryRepository;
+    private final InquiryResponseRepository inquiryResponseRepository;
     private final UserRepository userRepository;
 
     // 게시글 목록 조회
-    @Transactional
     public List<InquiryListDto> getInquiries() {
         return inquiryRepository.findAll().stream().map(
             inquiry -> new InquiryListDto(inquiry.getId(), inquiry.getTitle(),
@@ -30,20 +36,61 @@ public class InquiryService {
     }
 
     // 게시글 상세 조회
-    @Transactional
     public InquiryDetailDto getInquiryDetails(Long id) {
         Inquiry inquiry = inquiryRepository.findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("해당 id의 문의를 찾을 수 없습니다: " + id));
+            .orElseThrow(() -> new IllegalArgumentException("해당 ID의 문의를 찾을 수 없습니다: " + id));
         return InquiryMapper.toResponseDto(inquiry);
     }
 
     // 게시글 작성
     @Transactional
-    public Long createInquiry(InquiryWriteDto requestDto, String userEmail) {
-        User user = userRepository.findByEmail(userEmail).orElseThrow(
-            () -> new IllegalArgumentException("해당 이메일의 유저를 찾을 수 없습니다: " + userEmail));
+    public Long createInquiry(InquiryWriteDto requestDto, String nickname) {
+        User user = userRepository.findByNickname(nickname)
+            .orElseThrow(() -> new IllegalArgumentException("해당 이메일의 유저를 찾을 수 없습니다: " + nickname));
         Inquiry inquiry = InquiryMapper.toEntity(requestDto, user);
         inquiryRepository.save(inquiry);
         return inquiry.getId();
+    }
+
+    // 답글 달기
+    @Transactional
+    public InquiryResponseDto createResponse(Long id, InquiryResponseDto responseDto,
+        Long adminId) {
+        Inquiry inquiry = inquiryRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("해당 ID의 문의를 찾을 수 없습니다: " + id));
+
+        User admin = userRepository.findById(adminId)
+            .orElseThrow(() -> new IllegalArgumentException("해당 ID의 관리자를 찾을 수 없습니다: " + adminId));
+
+        inquiry.updateInquiryStatus(responseDto);
+        inquiryRepository.save(inquiry);
+
+        InquiryResponse response = InquiryResponseMapper.toInquiryResponseEntity(responseDto,
+            inquiry, admin);
+        InquiryResponse savedResponse = inquiryResponseRepository.save(response);
+
+        return InquiryResponseMapper.toInquiryResponseDto(savedResponse);
+    }
+
+    // 제목으로 검색
+    public List<InquiryListDto> searchInquiriesByTitle(String title) {
+        return inquiryRepository.findByTitleContaining(title).stream()
+            .map(InquiryMapper::toInquiryListDto).collect(Collectors.toList());
+    }
+
+    // 닉네임으로 검색
+    public List<InquiryListDto> searchInquiriesByNickname(String nickname) {
+        return inquiryRepository.findByUser_NicknameContaining(nickname).stream()
+            .map(InquiryMapper::toInquiryListDto).collect(Collectors.toList());
+    }
+
+    // 게시글 상태 변경
+    @Transactional
+    public void updateInquiryStatus(Long id, InquiryStatusUpdateDto statusUpdateDto) {
+        Inquiry inquiry = inquiryRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("해당 ID의 문의를 찾을 수 없습니다: " + id));
+
+        inquiry.updateInquiryStatus(statusUpdateDto);
+        inquiryRepository.save(inquiry);
     }
 }

--- a/src/main/java/trend_setter/turtlerun/inquiry/utils/InquiryMapper.java
+++ b/src/main/java/trend_setter/turtlerun/inquiry/utils/InquiryMapper.java
@@ -1,5 +1,6 @@
 package trend_setter.turtlerun.inquiry.utils;
 
+import trend_setter.turtlerun.inquiry.dto.InquiryListDto;
 import trend_setter.turtlerun.inquiry.dto.InquiryWriteDto;
 import trend_setter.turtlerun.inquiry.dto.InquiryDetailDto;
 import trend_setter.turtlerun.inquiry.entity.Inquiry;
@@ -16,5 +17,14 @@ public class InquiryMapper {
     public static InquiryDetailDto toResponseDto(Inquiry inquiry) {
         return new InquiryDetailDto(inquiry.getId(), inquiry.getTitle(), inquiry.getContent(),
             inquiry.getInquiryStatus(), inquiry.getUser().getEmail());
+    }
+
+    // Inquiry 엔티티 -> InquiryListDto
+    public static InquiryListDto toInquiryListDto(Inquiry inquiry) {
+        return new InquiryListDto(
+            inquiry.getId(),
+            inquiry.getTitle(),
+            inquiry.getInquiryStatus()
+        );
     }
 }

--- a/src/main/java/trend_setter/turtlerun/inquiry/utils/InquiryResponseMapper.java
+++ b/src/main/java/trend_setter/turtlerun/inquiry/utils/InquiryResponseMapper.java
@@ -1,0 +1,26 @@
+package trend_setter.turtlerun.inquiry.utils;
+
+import trend_setter.turtlerun.inquiry.dto.InquiryResponseDto;
+import trend_setter.turtlerun.inquiry.entity.Inquiry;
+import trend_setter.turtlerun.inquiry.entity.InquiryResponse;
+import trend_setter.turtlerun.user.User;
+
+public class InquiryResponseMapper {
+
+    // InquiryResponseDto -> InquiryResponse 엔티티
+    public static InquiryResponse toInquiryResponseEntity(InquiryResponseDto responseDto,
+        Inquiry inquiry, User admin) {
+        return InquiryResponse.builder()
+            .inquiry(inquiry)
+            .user(admin)
+            .response(responseDto.response())
+            .build();
+    }
+
+    // InquiryResponse 엔티티 -> InquiryResponseDto
+    public static InquiryResponseDto toInquiryResponseDto(InquiryResponse inquiryResponse) {
+        return new InquiryResponseDto(
+            inquiryResponse.getResponse()
+        );
+    }
+}


### PR DESCRIPTION
## 💡 이슈
- resolve #40 

## 🤩 개요
문의하기 기능을 구현합니다.

## 🧑‍💻 작업 사항
- InquiryDto 인터페이스 및 Inquiry 엔티티에 StatusUpdate 로직 추가
- 관리자의 답변 등록
- 관리자의 문의 검색
- 문의 상태 변경

## 📖 참고 사항
마이페이지에서 내가 쓴 문의 확인 및 권한 설정에 대해서는 이후 추가하겠습니다.